### PR TITLE
Add stub lookup and import endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # langer
 Language Learning app
+
+## Backend Go Server
+
+The `backend-go` directory contains a small Go web server with several stub endpoints:
+
+- `/ping` returns a simple JSON response for health checks.
+- `/lookup` looks up a word or phrase, returning placeholder translation and knowledge information.
+- `/import` accepts new articles or audio files for processing.
+- `/content` serves previously imported content.
+
+### Building
+
+```bash
+cd backend-go
+go build -o langer-server
+```
+
+### Running
+
+```bash
+./langer-server
+```
+
+The server listens on port `8080` by default.

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/yourusername/langer/backend-go
+
+go 1.23.8

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type PingResponse struct {
+	Message string `json:"message"`
+}
+
+type LookupResponse struct {
+	Translation string `json:"translation"`
+	Knowledge   string `json:"knowledge"`
+}
+
+func pingHandler(w http.ResponseWriter, r *http.Request) {
+	res := PingResponse{Message: "pong"}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}
+
+func lookupHandler(w http.ResponseWriter, r *http.Request) {
+	res := LookupResponse{Translation: "not implemented", Knowledge: "unknown"}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}
+
+type ImportResponse struct {
+	Status string `json:"status"`
+}
+
+func importHandler(w http.ResponseWriter, r *http.Request) {
+	res := ImportResponse{Status: "not implemented"}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}
+
+type ContentResponse struct {
+	Data string `json:"data"`
+}
+
+func contentHandler(w http.ResponseWriter, r *http.Request) {
+	res := ContentResponse{Data: "not implemented"}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}
+
+func main() {
+	http.HandleFunc("/ping", pingHandler)
+	http.HandleFunc("/lookup", lookupHandler)
+	http.HandleFunc("/import", importHandler)
+	http.HandleFunc("/content", contentHandler)
+
+	log.Println("Listening on :8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- extend Go backend with `/lookup`, `/import`, and `/content`
- update README with descriptions of the new stub endpoints

## Testing
- `go vet ./...`
- `go build -o /tmp/langer-server`


------
https://chatgpt.com/codex/tasks/task_e_685dab57c328832286520c33653efa2f