### PR TITLE
Add single-click text selection and adjuster

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ go build -o langer-server
 ./langer-server
 ```
 
-The server listens on port `8080` by default.
+The server listens on port `8080` by default and serves files from the `static/` directory.
+Open `http://localhost:8080/` after running the server to see the first available content.

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"sync"
 )
 
 type PingResponse struct {
@@ -14,6 +15,11 @@ type LookupResponse struct {
 	Translation string `json:"translation"`
 	Knowledge   string `json:"knowledge"`
 }
+
+var (
+	contents []string
+	mtx      sync.Mutex
+)
 
 func pingHandler(w http.ResponseWriter, r *http.Request) {
 	res := PingResponse{Message: "pong"}
@@ -32,7 +38,19 @@ type ImportResponse struct {
 }
 
 func importHandler(w http.ResponseWriter, r *http.Request) {
-	res := ImportResponse{Status: "not implemented"}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	text := r.FormValue("text")
+	if text == "" {
+		http.Error(w, "missing text", http.StatusBadRequest)
+		return
+	}
+	mtx.Lock()
+	contents = append(contents, text)
+	mtx.Unlock()
+	res := ImportResponse{Status: "ok"}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(res)
 }
@@ -42,16 +60,26 @@ type ContentResponse struct {
 }
 
 func contentHandler(w http.ResponseWriter, r *http.Request) {
-	res := ContentResponse{Data: "not implemented"}
+	mtx.Lock()
+	var text string
+	if len(contents) > 0 {
+		text = contents[0]
+	}
+	mtx.Unlock()
+	res := ContentResponse{Data: text}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(res)
 }
 
 func main() {
+	contents = append(contents, "Hello World! This is sample content.")
+
 	http.HandleFunc("/ping", pingHandler)
 	http.HandleFunc("/lookup", lookupHandler)
 	http.HandleFunc("/import", importHandler)
 	http.HandleFunc("/content", contentHandler)
+	fs := http.FileServer(http.Dir("static"))
+	http.Handle("/", fs)
 
 	log.Println("Listening on :8080")
 	if err := http.ListenAndServe(":8080", nil); err != nil {

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Langer MVP</title>
+  <style>
+  body { font-family: sans-serif; margin: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>Langer MVP</h1>
+  <div id="content">Loading...</div>
+  <div id="translation"></div>
+<script>
+fetch('/content').then(r => r.json()).then(data => {
+  document.getElementById('content').textContent = data.data || 'No content';
+});
+
+function adjustSelection() {
+  const sel = window.getSelection();
+  if (!sel.rangeCount || sel.isCollapsed) return;
+  const range = sel.getRangeAt(0);
+  if (range.startContainer !== range.endContainer || range.startContainer.nodeType !== Node.TEXT_NODE) {
+    return;
+  }
+  const text = range.startContainer.textContent;
+  let start = range.startOffset;
+  let end = range.endOffset;
+  while (start > 0 && !/\s/.test(text[start - 1])) start--;
+  while (end < text.length && !/\s/.test(text[end])) end++;
+  range.setStart(range.startContainer, start);
+  range.setEnd(range.endContainer, end);
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+document.addEventListener('selectionchange', () => {
+  adjustSelection();
+  const sel = window.getSelection();
+  const out = document.getElementById('translation');
+  out.textContent = sel.rangeCount && !sel.isCollapsed ? 'Selected: ' + sel.toString() : '';
+});
+
+document.getElementById('content').addEventListener('click', (e) => {
+  const cr = document.caretRangeFromPoint ? document.caretRangeFromPoint(e.clientX, e.clientY)
+                                          : document.caretPositionFromPoint(e.clientX, e.clientY);
+  if (!cr) return;
+  let node = cr.startContainer;
+  if (node.nodeType !== Node.TEXT_NODE) return;
+  const text = node.textContent;
+  let start = cr.startOffset;
+  if (/\s/.test(text[start])) return;
+  let end = start;
+  while (start > 0 && !/\s/.test(text[start - 1])) start--;
+  while (end < text.length && !/\s/.test(text[end])) end++;
+  const r = document.createRange();
+  r.setStart(node, start);
+  r.setEnd(node, end);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(r);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show translation area
- add selection adjuster to snap text selections to word boundaries
- allow single-click selection of a word within the displayed content

## Testing
- `gofmt -w backend-go/main.go`
- `go build -o langer-server`

------
https://chatgpt.com/codex/tasks/task_e_685da8f0e5108322b76a93f16eaa1fc6