### PR TITLE
Add token highlighting frontend

### DIFF
--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 )
 
 type PingResponse struct {
@@ -38,11 +39,13 @@ func importHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type ContentResponse struct {
-	Data string `json:"data"`
+	Tokens []string `json:"tokens"`
 }
 
 func contentHandler(w http.ResponseWriter, r *http.Request) {
-	res := ContentResponse{Data: "not implemented"}
+	sample := "This is a sample article used for demonstration purposes."
+	tokens := strings.Fields(sample)
+	res := ContentResponse{Tokens: tokens}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(res)
 }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,55 @@
+function TokenViewer() {
+  const [tokens, setTokens] = React.useState([]);
+  const [selection, setSelection] = React.useState({start: null, end: null});
+  const [isSelecting, setIsSelecting] = React.useState(false);
+
+  React.useEffect(() => {
+    fetch('/content')
+      .then(res => res.json())
+      .then(data => {
+        if (data && Array.isArray(data.tokens)) {
+          setTokens(data.tokens);
+        }
+      });
+  }, []);
+
+  const handleMouseDown = index => {
+    setIsSelecting(true);
+    setSelection({start: index, end: index});
+  };
+
+  const handleMouseEnter = index => {
+    if (isSelecting) {
+      setSelection(sel => ({...sel, end: index}));
+    }
+  };
+
+  const handleMouseUp = () => {
+    setIsSelecting(false);
+  };
+
+  const isHighlighted = index => {
+    const {start, end} = selection;
+    if (start === null || end === null) return false;
+    const [s, e] = start < end ? [start, end] : [end, start];
+    return index >= s && index <= e;
+  };
+
+  return (
+    <div className="text" onMouseUp={handleMouseUp}>
+      {tokens.map((tok, idx) => (
+        <span
+          key={idx}
+          className={'token' + (isHighlighted(idx) ? ' highlight' : '')}
+          onMouseDown={() => handleMouseDown(idx)}
+          onMouseEnter={() => handleMouseEnter(idx)}
+        >
+          {tok}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+ReactDOM.render(<TokenViewer />, document.getElementById('root'));
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Langer Frontend</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: sans-serif;
+  padding: 20px;
+}
+
+.token {
+  display: inline-block;
+  margin-right: 4px;
+  cursor: default;
+}
+
+.token.highlight {
+  border: 2px solid blue;
+  border-radius: 6px;
+  padding: 2px;
+}


### PR DESCRIPTION
## Summary
- build an example `/content` endpoint with sample tokens
- add a minimal React-based frontend for tokenized text selection

## Testing
- `go build -o /tmp/langer-server`

------
https://chatgpt.com/codex/tasks/task_e_685ec767d8b08322972e32b78991fd64